### PR TITLE
Increase Home Profile Image Size on Mobile

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -19,6 +19,7 @@ showQr = false
 showContact = false
 sections = ["approach", "services","experience","education", "volunteering","blog"]
 description="Dora Costa, a counselling psychologist in Paralimni, Cyprus, offers in-person and online sessions. Specializing in CBT, ADHD support, and addiction counselling, she helps individuals, couples, and families build resilience and achieve personal growth."
+customCSS = ["css/custom.css"]
 
 
 [params.google]

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,8 @@
+/* Increase home profile image size slightly on mobile */
+@media (max-width: 450px) {
+  /* Target the profile image */
+  img[src*="profile_scaled.jpg"] {
+    width: 120px !important;
+    height: 120px !important;
+  }
+}


### PR DESCRIPTION
This pull request modifies the homepage's profile image size to ensure better visibility on mobile devices. Specifically, a custom CSS file has been added to adjust the image dimensions for screens with a width of 450px or less, increasing the size to 120x120 pixels. This change addresses the issue of the image appearing too small on devices like the Z Fold 5, enhancing the user experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [dorasite/amt99llcsa6o](https://cosine.sh/qm4n9p2oxcjz/dorasite/task/amt99llcsa6o)
Author: Adamos
